### PR TITLE
Add SQLite extension check

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "io238/laravel-iso-countries",
-    "version": "1.3.0",
+    "version": "1.3.1",
     "description": "Ready-to-use Laravel models and relations for country (ISO 3166),  language (ISO 639-1), and currency (ISO 4217) information with multi-language support.",
     "keywords": [
         "laravel",

--- a/src/Exceptions/MissingSqliteExtensionException.php
+++ b/src/Exceptions/MissingSqliteExtensionException.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Io238\ISOCountries\Exceptions;
+
+use Exception;
+
+class MissingSqliteExtensionException extends Exception
+{
+    protected $message = 'The PHP extension pdo_sqlite is not installed or enabled. This package requires the SQLite extension.';
+}

--- a/src/ISOCountriesServiceProvider.php
+++ b/src/ISOCountriesServiceProvider.php
@@ -5,6 +5,8 @@ namespace Io238\ISOCountries;
 use Illuminate\Support\ServiceProvider;
 use Io238\ISOCountries\Commands\Build;
 
+use Io238\ISOCountries\Exceptions\MissingSqliteExtensionException;
+
 
 class ISOCountriesServiceProvider extends ServiceProvider {
 
@@ -13,6 +15,10 @@ class ISOCountriesServiceProvider extends ServiceProvider {
 
     public function boot()
     {
+        // Prüfe, ob die SQLite-Erweiterung geladen ist
+        if (!extension_loaded('pdo_sqlite')) {
+            throw new MissingSqliteExtensionException();
+        }
         // Create custom database connection
 
         // Use Sqlite database path from config, if it exists


### PR DESCRIPTION
Introduce a new exception for missing SQLite extensions and implement a check in the service provider to ensure the extension is loaded. Update the package version to 1.3.1 in composer.json.