### PR TITLE
fix typo on readme about build command

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ This is the contents of the published config file:
 After making changes to the config you need to re-build the database with the following command:
 
 ```bash
-php artisan db:seed countries:build
+php artisan countries:build
 ```
 
 This will create a new SQLITE database and stores it in your project at `database/iso-countries.sqlite`. Exclude this


### PR DESCRIPTION
This PR fixes a README typo on the re-build database command.

It throws this error:

```
 Illuminate\Contracts\Container\BindingResolutionException 

  Target class [Database\Seeders\countries:build] does not exist.
```